### PR TITLE
fix: allow underscore in filename

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -91,7 +91,7 @@ class File
 			throw new Exception("Invalid file");
 		}
 
-		$path = str_replace(array("\\", "_"), "/", $path);
+		$path = str_replace(array("\\"), "/", $path);
 		$parts = explode("/", $path);
 
 		if (!$filename) {


### PR DESCRIPTION
Issue https://github.com/rbaskam/LaravelPCloud/issues/1 relates to the file names having the underscore removed from them. This fix will allow them.

Converted their https://github.com/pCloud/pcloud-sdk-php package to a Laravel one so not sure why they did it.